### PR TITLE
docs: add AIxSET 2026 short paper acceptance

### DIFF
--- a/src/lib/components/news.svelte
+++ b/src/lib/components/news.svelte
@@ -51,6 +51,11 @@
     <h2 class="sec-title">Lab News</h2>
     <ul>
         <li>
+            <span class="date">[Aug 2026]</span>
+            Our short paper "Mixing Models for Enhanced Robustness" has been accepted
+            by AIxSET 2026! Congrats Chris!
+        </li>
+        <li>
             <span class="date">[Jul 2026]</span>
             Our paper "Visualize the Invisible: Exposing Causal Layers in GPU Performance
             Analysis through Milestone Abstractions" has been accepted by IEEE VIS

--- a/static/publication_list.json
+++ b/static/publication_list.json
@@ -1,5 +1,18 @@
 [
     {
+        "title": "Mixing Models for Enhanced Robustness",
+        "authors": "Chris Thames, Yifan Sun",
+        "venue": "AIxSET 2026",
+        "year": 2026,
+        "month": 9,
+        "day": 28,
+        "tags": ["yifan", "lab"],
+        "links": [],
+        "type": "conference",
+        "venue_full": "3rd IEEE International Conference on Artificial Intelligence x Science, Engineering, and Technology",
+        "identification_information": "Short paper (4 pages)."
+    },
+    {
         "title": "Visualize the Invisible: Exposing Causal Layers in GPU Performance Analysis through Milestone Abstractions",
         "authors": "Yuanhuan Deng, Katherine E. Isaacs, Yifan Sun",
         "venue": "IEEE VIS 2026",

--- a/static/publication_list.json
+++ b/static/publication_list.json
@@ -10,7 +10,7 @@
         "links": [],
         "type": "conference",
         "venue_full": "3rd IEEE International Conference on Artificial Intelligence x Science, Engineering, and Technology",
-        "identification_information": "Short paper (4 pages)."
+        "note": "Short paper."
     },
     {
         "title": "Visualize the Invisible: Exposing Causal Layers in GPU Performance Analysis through Milestone Abstractions",


### PR DESCRIPTION
## Summary

- add “Mixing Models for Enhanced Robustness” to Yifan Sun’s CV
- identify the AIxSET 2026 publication as a short paper using the publication `note` field
- add an August 2026 lab-news announcement congratulating Chris Thames

## Why

The paper was accepted for publication as a short paper at AIxSET 2026.

## Validation

- `npm run build` — passes
- JSON formatting check — passes
- `git diff --check` — passes
- `npm run check` — reports six pre-existing errors in unrelated older pages; neither edited file introduces a diagnostic