### PR TITLE
Update website for Class of 1953 Associate Professorship

### DIFF
--- a/src/routes/(lab)/people/+page.svelte
+++ b/src/routes/(lab)/people/+page.svelte
@@ -15,7 +15,7 @@
             name="Yifan Sun"
             profile_img="/yifan_profile.png"
             link="/syifan"
-            role="Assistant Professor"
+            role="Class of 1953 Associate Professor"
             email="profyifansun@gmail.com"
         >
             <div><b>Office:</b> ISC 4 1383</div>

--- a/src/routes/syifan/+page.svelte
+++ b/src/routes/syifan/+page.svelte
@@ -9,7 +9,7 @@
 
 <div>
     <p>
-        I am an Assistant Professor in the Department of Computer Science at
+        I am the Class of 1953 Associate Professor of Computer Science at
         William & Mary. I am the lead of the <a href="/"
             >Scalable Architecture Lab</a
         >. I received my Ph.D. degree from the Department of Electrical and

--- a/src/routes/syifan/YifanSidebar.svelte
+++ b/src/routes/syifan/YifanSidebar.svelte
@@ -19,7 +19,7 @@
             </div>
         </div>
         <div class="text-muted-foreground">
-            <p>Assistant Professor</p>
+            <p>Class of 1953 Associate Professor</p>
             <p>Computer Science</p>
             <p>William & Mary</p>
         </div>

--- a/static/cv/cv_data.yml
+++ b/static/cv/cv_data.yml
@@ -29,13 +29,13 @@ sections:
           - Computer Science, William & Mary
           - Williamsburg, VA
         meta:
-          - 8/10/2026 - Present
+          - 8/2026 - Present
       - content:
           - Assistant Professor
           - Computer Science, William & Mary
           - Williamsburg, VA
         meta:
-          - 8/2020 - 8/9/2026
+          - 8/2020 - 8/2026
     subsections: []
   - id: educationEntries
     title: Education

--- a/static/cv/cv_data.yml
+++ b/static/cv/cv_data.yml
@@ -2,7 +2,7 @@ version: 1
 header:
   name: Yifan Sun
   tags:
-    - Assistant Professor, Computer Science, William & Mary
+    - Class of 1953 Associate Professor, Computer Science, William & Mary
     - ISC 4 1383, Williamsburg, VA 23185
   contact:
     phone:
@@ -25,11 +25,17 @@ sections:
     title: Academic Appointments
     entries:
       - content:
+          - Class of 1953 Associate Professor
+          - Computer Science, William & Mary
+          - Williamsburg, VA
+        meta:
+          - 8/10/2026 - Present
+      - content:
           - Assistant Professor
           - Computer Science, William & Mary
           - Williamsburg, VA
         meta:
-          - 8/2020 - Present
+          - 8/2020 - 8/9/2026
     subsections: []
   - id: educationEntries
     title: Education


### PR DESCRIPTION
## Summary

- update the live CV header to `Class of 1953 Associate Professor, Computer Science, William & Mary`
- record both appointments using the CV's existing month/year convention:
  - Class of 1953 Associate Professor: `8/2026 - Present`
  - Assistant Professor: `8/2020 - 8/2026`
- update the current title on the lab people page, Yifan's profile introduction, and Yifan's sidebar

## Why

The CV and current profile surfaces still identified Yifan as an Assistant Professor. This records the August 2026 transition and keeps the website's canonical biographical content consistent.

## Whole-site audit

- remaining `Assistant Professor` source matches are historical records or refer to other faculty
- `static/yifan_cv.pdf` is an unlinked, publicly deployable legacy snapshot from September 2025; its source has been removed, so it is intentionally unchanged pending a separate replace-or-remove decision

## Validation

- CV YAML parsed successfully and uses the same month/year style as the rest of the active CV
- `npm run build` passed
- browser-verified `/syifan/cv`, `/syifan`, and `/people`; the title and date ranges render correctly with no console errors
- focused ESLint is unavailable because the repository has no ESLint v9 configuration; the sidebar's Prettier warning is pre-existing on `origin/main`
- repository-wide `npm run check` remains blocked by six pre-existing errors in unrelated legacy pages and a missing `feather-icons` declaration